### PR TITLE
📦 Added `repository` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "JavaScript library to interact with the Vinted API",
   "main": "index.js",
   "typings": "./index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Androz2091/vinted-api.git"
+  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
Hello, I added the `repository` property in package.json in order to have a link on the package's NPM page. [NPM doc about it](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository).