### PR TITLE
Fix typage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'vinted-api' {
     }
 
     export function fetchCookie (): Promise<string>;
-    export function parseVintedQuerystring (url: string): string;
+    export function parseVintedURL (url: string): string;
     export function search (url: string, disableOrder?: boolean, allowSwap?: boolean, customParams?: Record<string, string|number>): Promise<VintedSearchResult>;
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'vinted-api' {
     }
 
     export function fetchCookie (): Promise<string>;
-    export function parseVintedURL (url: string): string;
+    export function parseVintedURL (url: string): {validURL: boolean, domain?: RegExpMatchArray | null, querystring?: string};
     export function search (url: string, disableOrder?: boolean, allowSwap?: boolean, customParams?: Record<string, string|number>): Promise<VintedSearchResult>;
 
 }


### PR DESCRIPTION
# Typing
Le typing du TS était mauvais
* L'index renvoyait à une fonction qui n'existait pas 

## Erreur
Le typage renvoyait à `parseVintedQueryString()`, fonction qui n'existait pas

## Correction
Modification du fichier typage (index.d.ts) :
```diff
- export function parseVintedQuerystring (url: string): string;
+ export function parseVintedURL (url: string): {validURL: boolean, domain?: RegExpMatchArray | null, querystring?: string};
```